### PR TITLE
Effectful namespace

### DIFF
--- a/effectful-cache/README.md
+++ b/effectful-cache/README.md
@@ -37,4 +37,4 @@ runCacheIO (cache :: Data.Cache Int Int)
 See the [tests][tests] to see an example use.
 
 [effectful]: https://github.com/arybczak/effectful
-[tests]: https://github.com/Kleidukos/effectful-cache/blob/main/test/Main.hs
+[tests]: https://github.com/Kleidukos/effectful-contrib/blob/main/effectful-cache/test/Main.hs

--- a/effectful-cache/effectful-cache.cabal
+++ b/effectful-cache/effectful-cache.cabal
@@ -55,7 +55,7 @@ library
   hs-source-dirs:
     src
   exposed-modules:
-    Data.Cache.Effect
+    Effectful.Cache
   build-depends:
     base <= 4.17,
     cache,

--- a/effectful-cache/effectful-cache.cabal
+++ b/effectful-cache/effectful-cache.cabal
@@ -1,8 +1,8 @@
 cabal-version:    3.0
 name:             effectful-cache
 version:          0.0.1.0
-homepage:         https://github.com/Kleidukos/effectful-cache#readme
-bug-reports:      https://github.com/Kleidukos/effectful-cache/issues
+homepage:         https://github.com/Kleidukos/effectful-contrib/tree/main/effectful-cache#readme
+bug-reports:      https://github.com/Kleidukos/effectful-contrib/issues
 author:           Hécate Moonlight
 maintainer:       Hécate Moonlight
 license:          MIT

--- a/effectful-cache/src/Effectful/Cache.hs
+++ b/effectful-cache/src/Effectful/Cache.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE Strict #-}
 {-|
-  Module      : Data.Cache.Effect
+  Module      : Effectful.Cache
   Copyright   : © Hécate Moonlight, 2021
   License     : MIT
   Maintainer  : hecate@glitchbra.in
@@ -11,7 +11,7 @@
 
   An effect wrapper around Data.Cache for the Effectful ecosystem
 -}
-module Data.Cache.Effect
+module Effectful.Cache
   ( -- * The /Cache/ effect
     Cache(..)
     -- * Handlers

--- a/effectful-cache/test/Main.hs
+++ b/effectful-cache/test/Main.hs
@@ -7,7 +7,7 @@ import Prelude hiding (lookup)
 import Test.Hspec as H
 import qualified Utils as U
 
-import Data.Cache.Effect
+import Effectful.Cache
 
 main :: IO ()
 main = hspec spec

--- a/effectful-time/README.md
+++ b/effectful-time/README.md
@@ -20,7 +20,7 @@ processTime :: (Time :> es) => Eff es UTCTime
 import Data.Time (UTCTime)
 import qualified Data.Time as T
 
-import Data.Time.Effect (getCurrentTime)
+import Effectful.Time (getCurrentTime)
 
 usingTime :: (Time :> es) => Eff es UTCTime
 usingTime = do

--- a/effectful-time/README.md
+++ b/effectful-time/README.md
@@ -39,4 +39,4 @@ runCurrentTimePure (time :: UTCTime) usingTime
 See the [tests][tests] to see an example use.
 
 [effectful]: https://github.com/arybczak/effectful
-[tests]: https://github.com/Kleidukos/effectful-time/blob/main/test/Main.hs
+[tests]: https://github.com/Kleidukos/effectful-contrib/blob/main/effectful-time/test/Main.hs

--- a/effectful-time/effectful-time.cabal
+++ b/effectful-time/effectful-time.cabal
@@ -1,8 +1,8 @@
 cabal-version:    3.0
 name:             effectful-time
 version:          0.0.1.0
-homepage:         https://github.com/Kleidukos/effectful-time#readme
-bug-reports:      https://github.com/Kleidukos/effectful-time/issues
+homepage:         https://github.com/Kleidukos/effectful-contrib/tree/main/effectful-time#readme
+bug-reports:      https://github.com/Kleidukos/effectful-contrib/issues
 author:           Hécate Moonlight
 maintainer:       Hécate Moonlight
 license:          MIT
@@ -14,7 +14,7 @@ extra-source-files:
 
 source-repository head
   type: git
-  location: https://github.com/Kleidukos/effectful-time
+  location: https://github.com/Kleidukos/effectful-contrib
 
 common common-extensions
   default-extensions: ConstraintKinds

--- a/effectful-time/effectful-time.cabal
+++ b/effectful-time/effectful-time.cabal
@@ -68,7 +68,7 @@ library
   hs-source-dirs:
     src
   exposed-modules:
-    Data.Time.Effect
+    Effectful.Time
   build-depends:
     base <= 4.17,
     time,

--- a/effectful-time/src/Effectful/Time.hs
+++ b/effectful-time/src/Effectful/Time.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE Strict #-}
 {-|
-  Module      : Data.Time.Effect
+  Module      : Effectful.Time
   Copyright   : © Hécate Moonlight, 2021
   License     : MIT
   Maintainer  : hecate@glitchbra.in
@@ -8,7 +8,7 @@
 
   An effect wrapper around Data.Time for the Effectful ecosystem
 -}
-module Data.Time.Effect where
+module Effectful.Time where
 
 import Control.Monad.IO.Class
 import Data.Kind

--- a/effectful-time/test/Main.hs
+++ b/effectful-time/test/Main.hs
@@ -8,7 +8,7 @@ import Effectful.State.Local
 import Test.Hspec as H
 import qualified Utils as U
 
-import Data.Time.Effect
+import Effectful.Time
 
 main :: IO ()
 main = hspec spec


### PR DESCRIPTION
This PR moves the modules of the `effectful-cache` and the `effectful-time` package to the `Effectful.*` namespace as discussed in https://github.com/Kleidukos/effectful-contrib/pull/1#discussion_r703050868 .

In addition to that some dead links in the documentation and Cabal files were fixed.