### PR TITLE
Add handlers for the backends of the effectful-log-* packages

### DIFF
--- a/effectful-log-base/README.md
+++ b/effectful-log-base/README.md
@@ -17,8 +17,9 @@ This library provides the following modules:
   `Logging` effect and the functions associated with it are defined here.
   Additionally, this module provides the `MonadLog` instance for the `Eff` monad.
 - `Effectful.Log.Backend.*`
-  The modules in this namespace provide lifted versions of the functions found
-  in the corresponding namespace of the `log-base` package.
+  The modules in this namespace provide handlers for the `Logging` effect for a
+  specific backend. They also include lifted versions of the functions found in
+  the corresponding namespace of the `log-base` package.
 - `Effectful.Log.Logger`
   This module contains functions which are useful if you want to implement
   custom loggers.
@@ -50,9 +51,8 @@ import Effectful.Log.Backend.StandardOutput
 
 main :: IO ()
 main = runEff $ do
-  withSimpleStdOutLogger $ \logger -> do
-    runCurrentTimeIO . runLogging "main" logger LogInfo $ do
-      app
+  runCurrentTimeIO . runSimpleStdOutLogging "main" LogInfo $ do
+    app
 
 app :: (Logging :> es, Time :> es) => Eff es ()
 app = do

--- a/effectful-log-base/examples/StdoutExample.hs
+++ b/effectful-log-base/examples/StdoutExample.hs
@@ -12,9 +12,8 @@ import Effectful.Log.Backend.StandardOutput
 
 main :: IO ()
 main = runEff $ do
-  withSimpleStdOutLogger $ \logger -> do
-    runCurrentTimeIO . runLogging "main" logger LogInfo $ do
-      app
+  runCurrentTimeIO . runSimpleStdOutLogging "main" LogInfo $ do
+    app
 
 app :: (Logging :> es, Time :> es) => Eff es ()
 app = do

--- a/effectful-log-base/src/Effectful/Log/Backend/LogList.hs
+++ b/effectful-log-base/src/Effectful/Log/Backend/LogList.hs
@@ -1,7 +1,10 @@
 -- | LogList logging back-end.
 module Effectful.Log.Backend.LogList
   ( -- * Logging to lists
-    newLogList
+    runLogListLogging
+
+    -- * Bindings
+  , newLogList
   , getLogList
   , putLogList
   , clearLogList
@@ -11,13 +14,35 @@ module Effectful.Log.Backend.LogList
   , LogBase.LogList
   ) where
 
+import Data.Text (Text)
 import Effectful.Internal.Monad
 import Effectful.Monad
-import Log.Data (LogMessage)
+import Log (LogLevel, LogMessage)
 import Log.Backend.LogList (LogList)
 import qualified Log.Backend.LogList as LogBase
 
+import Effectful.Log
 import Effectful.Log.Logger
+
+-- | A handler for the 'Logging' effect that is logging to a 'LogList'.
+--
+-- Implemented using 'LogBase.withLogListLogger'.
+runLogListLogging
+  :: IOE :> es
+  => LogList
+  -> Text
+  -- ^ Application component name to use.
+  -> LogLevel
+  -- ^ The maximum log level allowed to be logged.
+  -> Eff (Logging : es) a
+  -- ^ The computation to run.
+  -> Eff es a
+runLogListLogging ll component maxLogLevel k =
+  withLogListLogger ll $ \logger -> do
+    runLogging component logger maxLogLevel k
+
+----------------------------------------
+-- Bindings
 
 -- | Lifted 'LogBase.newLogList'.
 newLogList :: IOE :> es => Eff es LogList

--- a/effectful-log-base/src/Effectful/Log/Backend/StandardOutput.hs
+++ b/effectful-log-base/src/Effectful/Log/Backend/StandardOutput.hs
@@ -2,21 +2,82 @@
 
 -- | Stdout logging back-end.
 module Effectful.Log.Backend.StandardOutput
-  ( withSimpleStdOutLogger
+  ( -- * Logging to stdout
+    runSimpleStdOutLogging
+  , runStdOutLogging
+  , runJsonStdOutLogging
+
+    -- * Bindings
+  , withSimpleStdOutLogger
   , withStdOutLogger
   , withJsonStdOutLogger
   ) where
 
+import Data.Text (Text)
 import qualified Data.Text.IO as Text
 import Data.Aeson as JSON
 import Effectful.Monad
 import Effectful.Internal.Monad
+import Log (LogLevel)
 import qualified Log as LogBase
 import qualified Log.Backend.StandardOutput as LogBase
 import System.IO (hFlush, stdout)
 import qualified Data.ByteString.Lazy.Char8 as BSL
 
+import Effectful.Log
 import Effectful.Log.Logger
+
+-- | A handler for the 'Logging' effect that is logging to stdout in a simple
+-- format.
+--
+-- Implemented using 'LogBase.withSimpleStdOutLogger'.
+runSimpleStdOutLogging
+  :: IOE :> es
+  => Text
+  -- ^ Application component name to use.
+  -> LogLevel
+  -- ^ The maximum log level allowed to be logged.
+  -> Eff (Logging : es) a
+  -- ^ The computation to run.
+  -> Eff es a
+runSimpleStdOutLogging component maxLogLevel k =
+  withSimpleStdOutLogger $ \logger -> do
+    runLogging component logger maxLogLevel k
+
+-- | A handler for the 'Logging' effect that is logging to stdout.
+--
+-- Implemented using 'LogBase.withStdOutLogger'.
+runStdOutLogging
+  :: IOE :> es
+  => Text
+  -- ^ Application component name to use.
+  -> LogLevel
+  -- ^ The maximum log level allowed to be logged.
+  -> Eff (Logging : es) a
+  -- ^ The computation to run.
+  -> Eff es a
+runStdOutLogging component maxLogLevel k = withStdOutLogger $ \logger -> do
+  runLogging component logger maxLogLevel k
+
+-- | A handler for the 'Logging' effect that is logging to stdout in the JSON
+-- format.
+--
+-- Implemented using 'LogBase.withJsonStdOutLogger'.
+runJsonStdOutLogging
+  :: IOE :> es
+  => Text
+  -- ^ Application component name to use.
+  -> LogLevel
+  -- ^ The maximum log level allowed to be logged.
+  -> Eff (Logging : es) a
+  -- ^ The computation to run.
+  -> Eff es a
+runJsonStdOutLogging component maxLogLevel k =
+  withJsonStdOutLogger $ \logger -> do
+    runLogging component logger maxLogLevel k
+
+----------------------------------------
+-- Bindings
 
 -- | Lifted 'LogBase.withSimpleStdOutLogger'.
 withSimpleStdOutLogger :: IOE :> es => (Logger -> Eff es a) -> Eff es a

--- a/effectful-log-base/src/Effectful/Log/Backend/StandardOutput/Bulk.hs
+++ b/effectful-log-base/src/Effectful/Log/Backend/StandardOutput/Bulk.hs
@@ -2,18 +2,63 @@
 
 -- | Bulk stdout logging back-end.
 module Effectful.Log.Backend.StandardOutput.Bulk
-  ( withBulkStdOutLogger
+  ( -- * Bulk logging to stdout
+    runBulkStdOutLogging
+  , runBulkJsonStdOutLogging
+
+    -- * Bindings
+  , withBulkStdOutLogger
   , withBulkJsonStdOutLogger
   ) where
 
 import qualified Data.Aeson as JSON
+import Data.Text (Text)
 import qualified Data.Text.IO as Text
 import qualified Data.ByteString.Lazy.Char8 as BSL
 import Effectful.Monad
+import Log (LogLevel)
 import qualified Log as LogBase
 import System.IO (hFlush, stdout)
 
+import Effectful.Log
 import Effectful.Log.Logger
+
+-- | A handler for the 'Logging' effect that is logging to stdout once per
+-- second.
+--
+-- Implemented using 'LogBase.withBulkStdOutLogger'.
+runBulkStdOutLogging
+  :: IOE :> es
+  => Text
+  -- ^ Application component name to use.
+  -> LogLevel
+  -- ^ The maximum log level allowed to be logged.
+  -> Eff (Logging : es) a
+  -- ^ The computation to run.
+  -> Eff es a
+runBulkStdOutLogging component maxLogLevel k =
+  withBulkStdOutLogger $ \logger -> do
+    runLogging component logger maxLogLevel k
+
+-- | A handler for the 'Logging' effect that is logging to stdout in the JSON
+-- format once per second.
+--
+-- Implemented using 'LogBase.withBulkJsonStdOutLogger'.
+runBulkJsonStdOutLogging
+  :: IOE :> es
+  => Text
+  -- ^ Application component name to use.
+  -> LogLevel
+  -- ^ The maximum log level allowed to be logged.
+  -> Eff (Logging : es) a
+  -- ^ The computation to run.
+  -> Eff es a
+runBulkJsonStdOutLogging component maxLogLevel k =
+  withBulkJsonStdOutLogger $ \logger -> do
+    runLogging component logger maxLogLevel k
+
+----------------------------------------
+-- Bindings
 
 -- | Lifted 'LogBase.withBulkStdOutLogger'.
 withBulkStdOutLogger :: IOE :> es => (Logger -> Eff es a) -> Eff es a

--- a/effectful-log-base/src/Effectful/Log/Backend/Text.hs
+++ b/effectful-log-base/src/Effectful/Log/Backend/Text.hs
@@ -1,14 +1,41 @@
 -- | A logger that produces in-memory 'Text' values. Mainly useful for
 -- testing.
 module Effectful.Log.Backend.Text
-  ( withSimpleTextLogger
+  ( -- * Logging to an in-memory text value
+    runSimpleTextLogging
+
+    -- * Bindings
+  , withSimpleTextLogger
   ) where
 
 import Data.Text (Text)
-import qualified Log.Backend.Text as LogBase
 import Effectful.Internal.Monad
+import Effectful.Monad
+import Log (LogLevel)
+import qualified Log.Backend.Text as LogBase
 
+import Effectful.Log
 import Effectful.Log.Logger
+
+-- | A handler for the 'Logging' effect that is logging to an in-memory 'Text'
+-- value.
+--
+-- Implemented using 'LogBase.withSimpleTextLogger'.
+runSimpleTextLogging
+  :: IOE :> es
+  => Text
+  -- ^ Application component name to use.
+  -> LogLevel
+  -- ^ The maximum log level allowed to be logged.
+  -> Eff (Logging : es) a
+  -- ^ The computation to run.
+  -> Eff es (Text, a)
+runSimpleTextLogging component maxLogLevel k =
+  withSimpleTextLogger $ \logger -> do
+    runLogging component logger maxLogLevel k
+
+----------------------------------------
+-- Bindings
 
 -- | Lifted 'LogBase.withSimpleTextLogger'.
 withSimpleTextLogger :: (Logger -> Eff es a) -> Eff es (Text, a)

--- a/effectful-log-elasticsearch/README.md
+++ b/effectful-log-elasticsearch/README.md
@@ -1,20 +1,20 @@
-# effectful-elasicsearch
+# effectful-log-elasticsearch
 
 ## Description
 
 This package provides an [ElasticSearch][elasticsearch] logging backend for the
 [`effectful-log-base`][effectful-log-base] library.
-It contains versions of the functions found in the
-[`log-elasticsearch`][log-elasticsearch] package lifted to the `Eff` monad of
-the [effectful][effectful] library.
+It contains a handler for the `Logging` effect and versions of the functions
+found in the [`log-elasticsearch`][log-elasticsearch] package lifted to the
+`Eff` monad of the [effectful][effectful] library.
 
 ## How to use
 
 See the documentation of the
-[`effectful-log-base`](https://github.com/Kleidukos/effectful-contrib/tree/main/effectful-log-base#readme)
-package on how to use logging backends.
+[`effectful-log-base`](./effectful-log-base#readme) package on how to use
+logging backends.
 
 [effectful]: https://github.com/arybczak/effectful
-[effectful-log-base]: https://github.com/Kleidukos/effectful-contrib/tree/main/effectful-log-base
+[effectful-log-base]: ./effectful-log-base
 [elasticsearch]: https://www.elastic.co/elasticsearch/
 [log-elasticsearch]: https://hackage.haskell.org/package/log-elasticsearch

--- a/effectful-log-elasticsearch/effectful-log-elasticsearch.cabal
+++ b/effectful-log-elasticsearch/effectful-log-elasticsearch.cabal
@@ -21,7 +21,8 @@ common language
 
   default-language: Haskell2010
 
-  default-extensions:  FlexibleContexts
+  default-extensions:  DataKinds
+                       FlexibleContexts
                        TypeOperators
 
 library
@@ -36,6 +37,8 @@ library
 
   build-depends:    base <= 4.17
                   , effectful-core
+                  , effectful-log-base
                   , http-client
                   , log-base
                   , log-elasticsearch >= 0.10.0.0
+                  , text


### PR DESCRIPTION
This PR tries to improve the UX of the `effectful-log-*` packages: While we already provided lifted versions of the functions found in the respective `log-*` packages providing different, backend-specific handlers seems more appropriate for the use in an effect system.